### PR TITLE
fix(BEE-71685): Bump netty from 4.2.12.Final to 4.2.13.Final to fix GHSA-45q3-82m4-75jr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </scm>
 
   <properties>
-    <revision>4.2.12.Final</revision>
+    <revision>4.2.13.Final</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>


### PR DESCRIPTION
## Automated Fix - BEE-71685

**Ticket**: [BEE-71685](https://cloudbees.atlassian.net/browse/BEE-71685)

### Root Cause Summary
Bump netty from 4.2.12.Final to 4.2.13.Final to fix GHSA-45q3-82m4-75jr

### Changes
Files modified:
- pom.xml

### Build Results
`mvn verify` passed.

[WARNING] Tests run: 4, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 4.166 s -- in io.jenkins.plugins.netty_api.InjectedTest
[WARNING] Tests run: 4, Failures: 0, Errors: 0, Skipped: 1

---
> **AI Disclaimer**: This PR was generated by CloudBees AI Triage. It has passed
> compilation locally but should be reviewed by a human before merging.
> The fix was derived from automated root cause analysis of BEE-71685.