### PR TITLE
[JENKINS-76242] Bump netty from 4.2.12.Final to 4.2.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </scm>
 
   <properties>
-    <revision>4.2.12.Final</revision>
+    <revision>4.2.13.Final</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>


### PR DESCRIPTION
Bumps Netty from 4.2.12.Final to 4.2.13.Final to address:

- GHSA-f6hv-jmp6-3vwv (CVSS 7.5) - HTTP/2 decompression bomb DoS via br/zstd/snappy Content-Encoding
- GHSA-45q3-82m4-75jr - Netty codec vulnerability